### PR TITLE
Use pytest.mark.environ to set environment variables

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     sphinx
+    environ
 
 filterwarnings =
     ignore:'U' mode is deprecated:DeprecationWarning:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+@pytest.fixture(scope='function')
+def environ(request, monkeypatch):
+    """
+    Fixture to define environment variables before Sphinx App is created.
+
+    The test case needs to be marked as
+    ``@pytest.mark.environ(VARIABLE='value')`` with all the environment
+    variables wanted to define. Also, the test has to use this fixture before
+    the ``app`` once to have effect.
+
+    This idea is borrowed from,
+        https://github.com/sphinx-doc/sphinx/blob/3f6565df6323534e69d797003d8cb20e99c2c255/sphinx/testing/fixtures.py#L30
+    """
+    if hasattr(request.node, 'iter_markers'):  # pytest-3.6.0 or newer
+        markers = request.node.iter_markers('environ')
+    else:
+        markers = request.node.get_marker('environ')
+    pargs = {}
+    kwargs = {}
+
+    if markers is not None:
+        # to avoid stacking positional args
+        for info in reversed(list(markers)):
+            for i, a in enumerate(info.args):
+                pargs[i] = a
+            kwargs.update(info.kwargs)
+
+    for name, value in kwargs.items():
+        monkeypatch.setenv(name, value)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -534,9 +534,8 @@ def test_toctree_links_custom_settings(app, status, warning):
         assert chunk in content
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason='Our setup() function is called before the mock is executed.',
+@pytest.mark.environ(
+    READTHEDOCS_VERSION='v2.0.5',
 )
 @pytest.mark.sphinx(
     srcdir=srcdir,
@@ -544,8 +543,7 @@ def test_toctree_links_custom_settings(app, status, warning):
         'notfound_default_language': 'pt-br',
     },
 )
-def test_toctree_links_language_setting_version_environment(app, status, warning, monkeypatch):
-    monkeypatch.setenv('READTHEDOCS_VERSION', 'v2.0.5')
+def test_toctree_links_language_setting_version_environment(environ, app, status, warning):
     app.build()
 
     path = app.outdir / '404.html'


### PR DESCRIPTION
Use a helper to set environment variables _before_ the Sphinx app is created. This allows us to define these variables before our extension reads it.

Closes #65 