### PR TITLE
Fix URL_ROOT being set to "#"

### DIFF
--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -104,7 +104,7 @@ def finalize_media(app, pagename, templatename, context, doctree):
         if not baseuri.startswith('/'):
             raise BaseURIError('"baseuri" must be absolute')
 
-        if otheruri and not otheruri.startswith('/'):
+        if not otheruri.startswith('/'):
             otheruri = '/' + otheruri
 
         if otheruri:


### PR DESCRIPTION
The URL_ROOT setting in DOCUMENTATION_OPTIONS for the 404 page was being set to the odd value "#", causing my JavaScript code to no longer function.  This change fixes that.