### PR TITLE
Implement `notfound_urls_prefix` to replace 3 deprecated configs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -99,6 +99,11 @@ For other use cases, you can customize these configuration options in your ``con
 
    Type: string
 
+   .. warning::
+
+      Make sure this config starts and ends with a ``/``.
+      Otherwise, you may have unexpected behaviours.
+
    .. tip::
 
       The prefix can be completely removed by setting it to ``None``.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -17,11 +17,20 @@ For other use cases, you can customize these configuration options in your ``con
 
    Context passed to the template defined by ``notfound_template``.
 
-   Default: ``{'title': 'Page not found', 'body': '<h1>Page not found</h1>\n\nThanks for trying.'}``
+   Default:
+
+   .. code-block:: python
+
+      {
+          'title': 'Page not found',
+          'body': '<h1>Page not found</h1>\n\nThanks for trying.',
+      }
 
    Type: dict
 
-   Notes: If you prefer, you can create a file called ``404.rst`` and use reStructuredText to create the context of your ``404.html`` page.
+   .. note::
+
+      If you prefer, you can create a file called ``404.rst`` and use reStructuredText to create the context of your ``404.html`` page.
 
 .. confval:: notfound_pagename
 
@@ -39,8 +48,14 @@ For other use cases, you can customize these configuration options in your ``con
 
    Type: string
 
-   Notes: All links generated will have this prefix (e.g. ``/en/``).
-   This setting works with ``notfound_default_version`` to create a prefix for all URLs.
+   .. note::
+
+      All links generated will have this prefix (e.g. ``/en/``).
+      This setting works with ``notfound_default_version`` to create a prefix for all URLs.
+
+   .. deprecated:: 0.5
+
+      ``notfound_default_language`` is deprecated.  Use :confval:`notfound_urls_prefix` instead
 
 .. confval:: notfound_default_version
 
@@ -50,8 +65,14 @@ For other use cases, you can customize these configuration options in your ``con
 
    Type: string
 
-   Notes: All links generated will have this prefix (e.g. ``/latest/``).
-   This setting works with ``notfound_default_language`` to create a prefix for all URLs.
+   .. note::
+
+      All links generated will have this prefix (e.g. ``/latest/``).
+      This setting works with ``notfound_default_language`` to create a prefix for all URLs.
+
+   .. deprecated:: 0.5
+
+      ``notfound_default_version`` is deprecated.  Use :confval:`notfound_urls_prefix` instead
 
 .. confval:: notfound_no_urls_prefix
 
@@ -61,4 +82,23 @@ For other use cases, you can customize these configuration options in your ``con
 
    Type: bool
 
-   Notes: If this option is set to ``True``, the extension omits any prefix values from the URLs, including explicit values for ``notfound_default_language`` and ``notfound_default_version``.
+   .. note::
+
+      If this option is set to ``True``, the extension omits any prefix values from the URLs,
+      including explicit values for ``notfound_default_language`` and ``notfound_default_version``.
+
+   .. deprecated:: 0.5
+
+      ``notfound_no_urls_prefix`` is deprecated.  Use :confval:`notfound_urls_prefix` instead
+
+.. confval:: notfound_urls_prefix
+
+   Prefix added to all the URLs generated in the 404 page.
+
+   Default: ``'/en/latest/'``
+
+   Type: string
+
+   .. tip::
+
+      The prefix can be completely removed by setting it to ``None``.

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -192,7 +192,7 @@ class OrphanMetadataCollector(EnvironmentCollector):
         app.env.metadata[app.config.notfound_pagename].update({'orphan': True})
 
 
-def handle_config(app, config):
+def handle_config(app, *args, **kwargs):
     """
     Handle deprecated configurations.
 
@@ -251,6 +251,8 @@ def setup(app):
 
     if sphinx.version_info > (1, 8, 0):
         app.connect('config-inited', handle_config)
+    else:
+        app.connect('builder-inited', handle_config)
 
     app.connect('html-collect-pages', html_collect_pages)
     app.connect('html-page-context', finalize_media)

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -238,7 +238,9 @@ def setup(app):
     # This config should replace the previous three
     app.add_config_value('notfound_urls_prefix', f'/en/{default_version}/', 'html')
 
-    app.connect('config-inited', handle_config)
+    if sphinx.version_info > (1, 8, 0):
+        app.connect('config-inited', handle_config)
+
     app.connect('html-collect-pages', html_collect_pages)
     app.connect('html-page-context', finalize_media)
     app.connect('doctree-resolved', doctree_resolved)

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -203,7 +203,10 @@ def handle_config(app, config):
     if app.config.notfound_urls_prefix == default:
         language = app.config.notfound_default_language
         version = app.config.notfound_default_version
-        app.config.notfound_urls_prefix = f'/{language}/{version}/'
+        app.config.notfound_urls_prefix = '/{language}/{version}/'.format(
+            language=language,
+            version=version,
+        )
 
     deprecated_configs = [
         'notfound_default_language',
@@ -213,7 +216,9 @@ def handle_config(app, config):
     for config in deprecated_configs:
         default, rebuild, types = app.config.values.get(config)
         if getattr(app.config, config) != default:
-            message = f'{config} is deprecated. Use "notfound_urls_prefix" instead.'
+            message = '{config} is deprecated. Use "notfound_urls_prefix" instead.'.format(
+                config=config,
+            )
             warnings.warn(message, DeprecationWarning, stacklevel=2)
 
 
@@ -236,7 +241,13 @@ def setup(app):
     app.add_config_value('notfound_no_urls_prefix', False, 'html')
 
     # This config should replace the previous three
-    app.add_config_value('notfound_urls_prefix', f'/en/{default_version}/', 'html')
+    app.add_config_value(
+        'notfound_urls_prefix',
+        '/en/{default_version}/'.format(
+            default_version=default_version,
+        ),
+        'html',
+    )
 
     if sphinx.version_info > (1, 8, 0):
         app.connect('config-inited', handle_config)

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -222,6 +222,22 @@ def handle_deprecated_configs(app, *args, **kwargs):
             warnings.warn(message, DeprecationWarning, stacklevel=2)
 
 
+def validate_configs(app, *args, **kwargs):
+    """
+    Validate configs.
+
+    Shows a warning if one of the configs is not valid.
+    """
+    default, rebuild, types = app.config.values.get('notfound_urls_prefix')
+    if app.config.notfound_urls_prefix != default:
+        if not all([
+                app.config.notfound_urls_prefix.startswith('/'),
+                app.config.notfound_urls_prefix.endswith('/'),
+        ]):
+            message = 'notfound_urls_prefix should start and end with "/" (slash)'
+            warnings.warn(message, UserWarning, stacklevel=2)
+
+
 def setup(app):
     default_context = {
         'title': 'Page not found',
@@ -251,8 +267,10 @@ def setup(app):
 
     if sphinx.version_info > (1, 8, 0):
         app.connect('config-inited', handle_deprecated_configs)
+        app.connect('config-inited', validate_configs)
     else:
         app.connect('builder-inited', handle_deprecated_configs)
+        app.connect('builder-inited', validate_configs)
 
     app.connect('html-collect-pages', html_collect_pages)
     app.connect('html-page-context', finalize_media)

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -1,6 +1,7 @@
 import docutils
 import os
 import sphinx
+import warnings
 
 from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.errors import ExtensionError
@@ -48,7 +49,7 @@ def finalize_media(app, pagename, templatename, context, doctree):
 
     Generate absolute URLs for resources (js, images, css, etc) to point to the
     right. For example, if a URL in the page is ``_static/js/custom.js`` it will
-    be replaced by ``/<notfound_default_language>/<notfound_default_version>/_static/js/custom.js``.
+    be replaced by ``<notfound_urls_prefix>/_static/js/custom.js``.
 
     On the other hand, if ``notfound_no_urls_prefix`` is set, it will be
     replaced by ``/_static/js/custom.js``.
@@ -96,9 +97,8 @@ def finalize_media(app, pagename, templatename, context, doctree):
             if app.config.notfound_no_urls_prefix:
                 baseuri = '/'
             else:
-                baseuri = '/{language}/{version}/'.format(
-                    language=app.config.notfound_default_language,
-                    version=app.config.notfound_default_version,
+                baseuri = '{prefix}'.format(
+                    prefix=app.config.notfound_urls_prefix or '/',
                 )
 
         if not baseuri.startswith('/'):
@@ -192,6 +192,31 @@ class OrphanMetadataCollector(EnvironmentCollector):
         app.env.metadata[app.config.notfound_pagename].update({'orphan': True})
 
 
+def handle_config(app, config):
+    """
+    Handle deprecated configurations.
+
+    Looks for old deprecated configurations, define the new ones and triggers
+    warnings for old configs.
+    """
+    default, rebuild, types = app.config.values.get('notfound_urls_prefix')
+    if app.config.notfound_urls_prefix == default:
+        language = app.config.notfound_default_language
+        version = app.config.notfound_default_version
+        app.config.notfound_urls_prefix = f'/{language}/{version}/'
+
+    deprecated_configs = [
+        'notfound_default_language',
+        'notfound_default_version',
+        'notfound_no_urls_prefix',
+    ]
+    for config in deprecated_configs:
+        default, rebuild, types = app.config.values.get(config)
+        if getattr(app.config, config) != default:
+            message = f'{config} is deprecated. Use "notfound_urls_prefix" instead.'
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+
+
 def setup(app):
     default_context = {
         'title': 'Page not found',
@@ -210,6 +235,10 @@ def setup(app):
     app.add_config_value('notfound_default_version', default_version, 'html')
     app.add_config_value('notfound_no_urls_prefix', False, 'html')
 
+    # This config should replace the previous three
+    app.add_config_value('notfound_urls_prefix', f'/en/{default_version}/', 'html')
+
+    app.connect('config-inited', handle_config)
     app.connect('html-collect-pages', html_collect_pages)
     app.connect('html-page-context', finalize_media)
     app.connect('doctree-resolved', doctree_resolved)

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -233,7 +233,7 @@ def validate_configs(app, *args, **kwargs):
     """
     default, rebuild, types = app.config.values.get('notfound_urls_prefix')
     if app.config.notfound_urls_prefix != default:
-        if not all([
+        if app.config.notfound_urls_prefix and not all([
                 app.config.notfound_urls_prefix.startswith('/'),
                 app.config.notfound_urls_prefix.endswith('/'),
         ]):

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -192,7 +192,7 @@ class OrphanMetadataCollector(EnvironmentCollector):
         app.env.metadata[app.config.notfound_pagename].update({'orphan': True})
 
 
-def handle_config(app, *args, **kwargs):
+def handle_deprecated_configs(app, *args, **kwargs):
     """
     Handle deprecated configurations.
 
@@ -250,9 +250,9 @@ def setup(app):
     )
 
     if sphinx.version_info > (1, 8, 0):
-        app.connect('config-inited', handle_config)
+        app.connect('config-inited', handle_deprecated_configs)
     else:
-        app.connect('builder-inited', handle_config)
+        app.connect('builder-inited', handle_deprecated_configs)
 
     app.connect('html-collect-pages', html_collect_pages)
     app.connect('html-page-context', finalize_media)

--- a/notfound/utils.py
+++ b/notfound/utils.py
@@ -64,9 +64,8 @@ def replace_uris(app, doctree, nodetype, nodeattr):
                 imagedir=imagedir,
             )
         else:
-            uri = '/{language}/{version}/{imagedir}{filename}'.format(
-                language=app.config.notfound_default_language,
-                version=app.config.notfound_default_version,
+            uri = '{prefix}{imagedir}{filename}'.format(
+                prefix=app.config.notfound_urls_prefix or '/',
                 imagedir=imagedir,
                 filename=uri,
             )

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,6 @@ filterwarnings =
     ignore:'U' mode is deprecated:DeprecationWarning:
     ignore:sphinx.builders.html.DirectoryHTMLBuilder is now deprecated.*:DeprecationWarning:
     ignore:sphinx.builders.html.DirectoryHTMLBuilder is now deprecated.*:PendingDeprecationWarning:
+    ignore:notfound_default_language is deprecated. Use "notfound_urls_prefix" instead.:DeprecationWarning:
+    ignore:notfound_default_version is deprecated. Use "notfound_urls_prefix" instead.:DeprecationWarning:
+    ignore:notfound_no_urls_prefix is deprecated. Use "notfound_urls_prefix" instead.:DeprecationWarning:


### PR DESCRIPTION
This new config, `notfound_urls_prefix`, replaces the old ones:

- notfound_default_language
- notfound_default_version
- notfound_no_urls_prefix

and triggers warnings if any of those are used.

The new setting is backward compatible.

Closes #80 
Closes #27 
Closes #94 