### PR TITLE
Remind about `:orphan:` in 404.rst, to silence build warnings

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -21,7 +21,7 @@ For other use cases, you can customize these configuration options in your ``con
 
    Type: dict
 
-   Notes: If you prefer, you can create a file called ``404.rst`` and use reStructuredText to create the context of your ``404.html`` page.
+   Notes: If you prefer, you can create a file called ``404.rst`` and use reStructuredText to create the context of your ``404.html`` page. Add the ``:orphan:`` `metadata <https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html#metadata>`__ to the top of ``404.rst``, to silence the spurious ``document isn't included in any toctree`` warning.
 
 .. confval:: notfound_pagename
 


### PR DESCRIPTION
A manual `404.rst` page is typically not included in any toctrees and so will receive a warning like:

```
WARNING: document isn't included in any toctree
```

This warning is spurious, and can be controlled with [the `:orphan:` file metadata](https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html#metadata). This PR adds a brief mention of `:orphan:` to remind people that it exists and is probably useful for the 404 page.