### PR TITLE
Add `notfound_url_prefix`

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -62,3 +62,13 @@ For other use cases, you can customize these configuration options in your ``con
    Type: bool
 
    Notes: If this option is set to ``True``, the extension omits any prefix values from the URLs, including explicit values for ``notfound_default_language`` and ``notfound_default_version``.
+
+.. confval:: notfound_url_prefix
+
+   Global URL prefix to be included as is (for ex. set ``/REPO_NAME`` to host on github pages with address YOUR_NAME.github.io/REPO_NAME/).
+
+   Default: `` `` (empty).
+
+   Type: string
+
+   Notes: this prefix will be included as is before anything else.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -19,6 +19,8 @@ Yes.
 
 You may want to set ``notfound_no_urls_prefix`` to ``True`` and then add ``permalink: /404.html`` in the `YAML front matter`_.
 
+If you didn't set paid domain - you should set ``notfound_url_prefix`` with ``/REPO_NAME``.
+
 .. _YAML front matter: http://jekyllrb.com/docs/frontmatter/
 
 

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -94,9 +94,10 @@ def finalize_media(app, pagename, templatename, context, doctree):
 
         if baseuri is None:
             if app.config.notfound_no_urls_prefix:
-                baseuri = '/'
+                baseuri = app.config.notfound_url_prefix + '/'
             else:
-                baseuri = '/{language}/{version}/'.format(
+                baseuri = '{prefix}/{language}/{version}/'.format(
+                    prefix=app.config.notfound_url_prefix,
                     language=app.config.notfound_default_language,
                     version=app.config.notfound_default_version,
                 )
@@ -212,6 +213,7 @@ def setup(app):
     app.add_config_value('notfound_default_language', 'en', 'html')
     app.add_config_value('notfound_default_version', default_version, 'html')
     app.add_config_value('notfound_no_urls_prefix', False, 'html')
+    app.add_config_value('notfound_url_prefix', '', 'html')
 
     app.connect('html-collect-pages', html_collect_pages)
     app.connect('html-page-context', finalize_media)

--- a/notfound/utils.py
+++ b/notfound/utils.py
@@ -59,12 +59,14 @@ def replace_uris(app, doctree, nodetype, nodeattr):
             uri = olduri.split('/')[-1]
 
         if app.config.notfound_no_urls_prefix:
-            uri = '/{imagedir}{filename}'.format(
+            uri = '{prefix}/{imagedir}{filename}'.format(
+                prefix=app.config.notfound_url_prefix,
                 filename=uri,
                 imagedir=imagedir,
             )
         else:
-            uri = '/{language}/{version}/{imagedir}{filename}'.format(
+            uri = '{prefix}/{language}/{version}/{imagedir}{filename}'.format(
+                prefix=app.config.notfound_url_prefix,
                 language=app.config.notfound_default_language,
                 version=app.config.notfound_default_version,
                 imagedir=imagedir,

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -583,3 +583,66 @@ def test_automatic_orphan(app, status, warning):
         assert app.env.metadata['404'] == {'orphan': True, 'nosearch': True}
     else:
         assert app.env.metadata['404'] == {'orphan': True}
+
+
+@pytest.mark.sphinx(
+    srcdir=srcdir,
+    confoverrides={
+        'notfound_no_urls_prefix': True,
+        'notfound_url_prefix': '/prefix'
+    },
+)
+def test_url_prefix_with_no_urls_prefix_setting(app, status, warning):
+    app.build()
+    path = app.outdir / '404.html'
+    assert path.exists()
+
+    content = open(path).read()
+
+    chunks = [
+        # sidebar URLs
+        '<h1 class="logo"><a href="/prefix/index.html">Python</a></h1>',
+        '<form class="search" action="/prefix/search.html" method="get">',
+        '<li><a href="/prefix/index.html">Documentation overview</a><ul>',
+
+        # resources
+        '<link rel="stylesheet" href="/prefix/_static/alabaster.css" type="text/css" />',
+        '<link rel="stylesheet" href="/prefix/_static/pygments.css" type="text/css" />',
+        '<link rel="stylesheet" href="/prefix/_static/custom.css" type="text/css" />',
+    ]
+
+    for chunk in chunks:
+        assert chunk in content
+
+
+@pytest.mark.sphinx(
+    srcdir=srcdir,
+    confoverrides={
+        'notfound_url_prefix': '/prefix'
+    },
+)
+@pytest.mark.sphinx(srcdir=srcdir)
+def test_url_prefix_with_default_settings(app, status, warning):
+    app.build()
+    path = app.outdir / '404.html'
+    assert path.exists()
+    content = open(path).read()
+
+    chunks = [
+        '<h1>Page not found</h1>',
+        'Thanks for trying.',
+        '<title>Page not found &#8212; Python  documentation</title>',
+
+        # sidebar URLs
+        '<h1 class="logo"><a href="/prefix/en/latest/index.html">Python</a></h1>',
+        '<form class="search" action="/prefix/en/latest/search.html" method="get">',
+        '<li><a href="/prefix/en/latest/index.html">Documentation overview</a><ul>',
+
+        # resources
+        '<link rel="stylesheet" href="/prefix/en/latest/_static/alabaster.css" type="text/css" />',
+        '<link rel="stylesheet" href="/prefix/en/latest/_static/pygments.css" type="text/css" />',
+        '<link rel="stylesheet" href="/prefix/en/latest/_static/custom.css" type="text/css" />',
+    ]
+
+    for chunk in chunks:
+        assert chunk in content


### PR DESCRIPTION
It may be needed for ex. with Github pages without paid domain

Signed-off-by: George Melikov <mail@gmelikov.ru>

If someone knows better variant to use this extension with Github pages without paid domain (i.e. with for ex. https://gmelikov.github.io/openzfs-docs/ ) - please open my eyes :)