### PR TITLE
Add warning about local web server for #95

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -21,6 +21,15 @@ You may want to set ``notfound_no_urls_prefix`` to ``True`` and then add ``perma
 
 .. _YAML front matter: http://jekyllrb.com/docs/frontmatter/
 
+Why is my local web server not showing a 404.html?
+--------------------------------------------------
+
+Simple web servers, such as ``http.server``, don't have a default handler for 404
+codes, so it doesn't know to point to the generated ``404.html``.
+
+To see an example of adding a custom request handler for 404 codes, see:
+https://stackoverflow.com/questions/22467908/python-simplehttpserver-404-page
+
 
 The answer I'm looking for is not here
 --------------------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -44,6 +44,9 @@ you can build your documentation again and you will see a new file called ``404.
 
    Do not worry too much about this, this is the expected behavior and those resources will appear once the docs are deployed.
 
+   If you can't see the 404.html file using a local simple web server, it is
+   most likely because they often don't support requests for 404 codes. Refer to
+   the :doc:`faq` for more information.
 
 .. note::
 


### PR DESCRIPTION
This is a pull request for #95, feel free to modify.

I also tried to run `make html` and got `No module named 'notfound'`, I'm not sure if `sphinx-notfound-page` should be added to **docs/requirements.txt**.