### PR TITLE
Override css_tag method

### DIFF
--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -1,5 +1,9 @@
 import docutils
-import html
+try:
+    from html import escape
+except ImportError:
+    from sphinx.util.pycompat import htmlescape as escape
+
 import os
 import sphinx
 import warnings
@@ -124,7 +128,7 @@ def finalize_media(app, pagename, templatename, context, doctree):
         for key in sorted(css.attributes):
             value = css.attributes[key]
             if value is not None:
-                attrs.append('%s="%s"' % (key, html.escape(value, True)))
+                attrs.append('%s="%s"' % (key, escape(value, True)))
         attrs.append('href="%s"' % pathto(css.filename, resource=True))
         return '<link %s />' % ' '.join(attrs)
 

--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -120,7 +120,7 @@ def finalize_media(app, pagename, templatename, context, doctree):
         uri = otheruri or '#'
         return uri
 
-    # https: // github.com/sphinx-doc/sphinx/blob/7138d03ba033e384f1e7740f639849ba5f2cc71d/sphinx/builders/html.py# L1067-L1076
+    # https://github.com/sphinx-doc/sphinx/blob/7138d03ba033e384f1e7740f639849ba5f2cc71d/sphinx/builders/html.py#L1067-L1076
     def css_tag(css):
         pathto = context.get("pathto")
         # type: (Stylesheet) -> str

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -19,6 +19,7 @@ rstsrcdir = os.path.join(
     '404rst',
 )
 
+
 @pytest.fixture(autouse=True, scope='function')
 def remove_sphinx_build_output():
     """Remove _build/ folder, if exist."""
@@ -32,8 +33,10 @@ def remove_sphinx_build_output():
 def test_parallel_build():
     # TODO: migrate to `app.build(..., parallel=2)` after merging
     # https://github.com/sphinx-doc/sphinx/pull/8257
-    subprocess.check_call('sphinx-build -j 2 -W -b html tests/examples/parallel-build build', shell=True)
-    
+    subprocess.check_call(
+        'sphinx-build -j 2 -W -b html tests/examples/parallel-build build', shell=True)
+
+
 @pytest.mark.sphinx(srcdir=srcdir)
 def test_404_page_created(app, status, warning):
     app.build()
@@ -678,3 +681,19 @@ def test_deprecation_warnings(app, status, warning):
 
     path = app.outdir / '404.html'
     assert path.exists()
+
+
+@pytest.mark.sphinx(srcdir=srcdir)
+def test_sphinx_custom_css(app, status, warning):
+    if sphinx.version_info >= (1, 8):
+        app.add_css_file("test_custom.css")
+    else:
+        app.add_stylesheet("test_custom.css")
+    app.build()
+    path = app.outdir / '404.html'
+    assert path.exists()
+
+    content = open(path).read()
+
+    css = '<link rel="stylesheet" type="text/css" href="/en/latest/_static/test_custom.css" />'
+    assert css in content

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -687,13 +687,15 @@ def test_deprecation_warnings(app, status, warning):
 def test_sphinx_custom_css(app, status, warning):
     if sphinx.version_info >= (1, 8):
         app.add_css_file("test_custom.css")
+        expected = '<link rel="stylesheet" type="text/css" href="/en/latest/_static/test_custom.css" />'
     else:
         app.add_stylesheet("test_custom.css")
+        expected = '<link rel="stylesheet" href="/en/latest/_static/test_custom.css" type="text/css" />'
+
     app.build()
     path = app.outdir / '404.html'
     assert path.exists()
 
     content = open(path).read()
 
-    css = '<link rel="stylesheet" type="text/css" href="/en/latest/_static/test_custom.css" />'
-    assert css in content
+    assert expected in content


### PR DESCRIPTION
I was having an issue where stylesheets added with `add_css_file` weren't being handled correctly, since they go through a hardcoded `pathto` in sphinx, instead of the `ctx['pathto']` method.

This fixes the issue, but it might also be better fixed upstream in sphinx? I'm not very familiar with the ecosystem, or what sphinx _should_ be doing here.