### PR TITLE
Test: make them work with docutils >= 0.17.x

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import docutils
 import pytest
 import sphinx
 import shutil
@@ -407,9 +408,13 @@ def test_image_on_404_rst_source(app, status, warning):
         chunks.append(
             u'<div class="figure align-center" id="id1">\n<img alt="/en/latest/_images/test.png" src="/en/latest/_images/test.png" />\n<p class="caption"><span class="caption-text">Description.</span><a class="headerlink" href="#id1" title="Permalink to this image">¶</a></p>\n</div>',
         )
-    else:
+    elif docutils.__version_info__ < (0, 17, 0):
         chunks.append(
             u'<div class="figure align-default" id="id1">\n<img alt="/en/latest/_images/test.png" src="/en/latest/_images/test.png" />\n<p class="caption"><span class="caption-text">Description.</span><a class="headerlink" href="#id1" title="Permalink to this image">¶</a></p>\n</div>',
+        )
+    else:
+        chunks.append(
+            u'<figure class="align-default" id="id1">\n<img alt="/en/latest/_images/test.png" src="/en/latest/_images/test.png" />\n<figcaption>\n<p><span class="caption-text">Description.</span><a class="headerlink" href="#id1" title="Permalink to this image">¶</a></p>\n</figcaption>\n</figure>',
         )
 
     for chunk in chunks:


### PR DESCRIPTION
Instead of `div class=figure`, docutils >= 0.17 uses `figure`.