### PR TITLE
Support CSS/JS files added by extensions in older Sphinx versions

### DIFF
--- a/tests/examples/extension/conf.py
+++ b/tests/examples/extension/conf.py
@@ -1,0 +1,13 @@
+# conf.py to run tests
+
+master_doc = 'index'
+extensions = [
+    'notfound.extension',
+]
+
+templates_path = ['_templates']
+
+
+def setup(app):
+    app.add_css_file('css_added_by_extension.css')
+    app.add_js_file('js_added_by_extension.js')

--- a/tests/examples/extension/index.rst
+++ b/tests/examples/extension/index.rst
@@ -1,0 +1,10 @@
+Example page
+============
+
+This is an example page.
+
+
+.. toctree::
+   :glob:
+
+   *

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,3 +15,20 @@ def _get_css_html_link_tag(language, version, filename):
         return '<link rel="stylesheet" type="text/css" href="{href}" />'.format(href=href)
     else:
         return '<link rel="stylesheet" href="{href}" type="text/css" />'.format(href=href)
+
+
+def _get_js_html_link_tag(language, version, filename):
+    if not language and not version:
+        src = '/_static/{filename}'.format(filename=filename)
+    else:
+        src = '/{language}/{version}/_static/{filename}'.format(
+            language=language,
+            version=version,
+            filename=filename,
+        )
+
+    if sphinx.version_info < (2, 4, 0):
+        return '<script type="text/javascript" src="{src}"></script>'.format(src=src)
+    else:
+        # #6925: html: Remove redundant type="text/javascript" from <script> elements
+        return '<script src="{src}"></script>'.format(src=src)


### PR DESCRIPTION
Older Sphinx versions does not have `setup_css_tag_helper` as 4.x does:
https://github.com/readthedocs/sphinx-notfound-page/pull/153/files#diff-83bfdb6415a043b1888e7ce5240bd78ea1f236af2f7094fcb5e7702f8672aa32R301

I'm using the old method for Sphinx<4.x which is pretty similar to how `toctree`
and `pathto` work.

Closes #120