### PR TITLE
Exclude commmon directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     description='Sphinx extension to build a 404 page with absolute URLs',
     url='https://github.com/readthedocs/sphinx-notfound-page',
     license='MIT',
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["common*"]),
     long_description=long_description,
     long_description_content_type='text/x-rst',
     include_package_data=True,


### PR DESCRIPTION
⚠️ Note: I just learned that the `build/` directory gets sort of cached. So, if you want to generate a clean wheel, you need to do

```
$ rm -rf build/
```

and then

```
$ python -m build [--wheel]
```

will do the right thing:

```
$ unzip -l dist/sphinx_notfound_page-0.6-py3-none-any.whl
Archive:  dist/sphinx_notfound_page-0.6-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
       20  2021-05-20 10:11   notfound/__init__.py
    12222  2021-05-20 10:11   notfound/extension.py
     3380  2021-05-20 10:11   notfound/utils.py
     1072  2021-05-20 10:15   sphinx_notfound_page-0.6.dist-info/LICENSE
     2374  2021-05-20 10:15   sphinx_notfound_page-0.6.dist-info/METADATA
       92  2021-05-20 10:15   sphinx_notfound_page-0.6.dist-info/WHEEL
        9  2021-05-20 10:15   sphinx_notfound_page-0.6.dist-info/top_level.txt
      668  2021-05-20 10:15   sphinx_notfound_page-0.6.dist-info/RECORD
---------                     -------
    19837                     8 files
```