### PR TITLE
Update faq for github pages to include usage of notfound_urls_prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 /tests/examples/404rst/_build
 package-lock.json
 node_modules
+
+# vscode
+.vscode/

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -21,6 +21,9 @@ Yes.
 You may want to set :confval:`notfound_urls_prefix` to ``None``,
 and then add ``permalink: /404.html`` in the `YAML front matter`_.
 
+If you are using the github provided domain, make sure to set the :confval:`notfound_urls_prefix` to your repository's name in between two forward slashes. For example if your repository is named ``MyRepo``, then ``notfound_urls_prefix = "/MyRepo/"``.
+
+
 .. _YAML front matter: http://jekyllrb.com/docs/frontmatter/
 
 Why is my local web server not showing a 404.html?

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx-tabs==3.2.0
 sphinx-rtd-theme==0.5.2
 sphinxemoji==0.1.8
 sphinx-autoapi==1.8.4
+sphinx-notfound-page


### PR DESCRIPTION
- Updated the faq for github pages to include usage of notfound_urls_prefix
- Updated .gitignore to exclude VSCode related files
- Updated requirements.txt to include sphinx-notfound-page itself for easier building 
  - You can just run `pip install -r requirements.txt` now and everything should work