### PR TITLE
Update test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,9 @@ jobs:
     steps:
       - run-tox:
           version: py310
+          # Do not run tests for Python 3.10 and Sphinx3 because it's broken
+          # See https://github.com/sphinx-doc/sphinx/issues/9816
+          sphinx-version: '1,2,4,latest'
   docs:
     docker:
       - image: 'cimg/python:3.10'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
         type: string
       sphinx-version:
         type: string
-        default: "1,2,3,latest"
+        default: "1,2,3,4,latest"
     steps:
       - checkout
       - run: pip install --user tox
@@ -46,9 +46,15 @@ jobs:
     steps:
       - run-tox:
           version: py39
+  py310:
+    docker:
+      - image: 'cimg/python:3.10'
+    steps:
+      - run-tox:
+          version: py310
   docs:
     docker:
-      - image: 'cimg/python:3.9'
+      - image: 'cimg/python:3.10'
     steps:
       - checkout
       - run: pip install --user tox
@@ -59,6 +65,7 @@ workflows:
   tests:
     jobs:
       - docs
+      - py310
       - py39
       - py38
       - py37

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,32 @@
 envlist =
   docs
   py27-sphinx1
-  py{36,37,38,39}-sphinx{1,2,3,latest}
+  py{36,37,38,39,310}-sphinx{1,2,3,4,latest}
 
 [testenv]
 deps =
   pytest
   pdbpp
   .
-  sphinx1: sphinx<2.0
-  sphinx2: sphinx<3.0
   sphinx3: sphinx<4.0
+  sphinx4: sphinx<5.0
   sphinxlatest: sphinx
 commands = pytest {posargs}
+
+# Pin docutils<0.18 for all Python versions using Sphinx 1.x or Sphinx 2.x
+# since it's incompatible and generating lot of errors
+# https://tox.wiki/en/latest/config.html#generating-environments-conditional-settings
+[testenv:py{27,36,37,38,39,310}-sphinx1]
+deps =
+  {[testenv]deps}
+  sphinx<2.0
+  docutils<0.18
+
+[testenv:py{36,37,38,39,310}-sphinx2]
+deps =
+  {[testenv]deps}
+  sphinx<3.0
+  docutils<0.18
 
 [testenv:py39-sphinx3]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,10 @@
 envlist =
   docs
   py27-sphinx1
-  py{36,37,38,39,310}-sphinx{1,2,3,4,latest}
+  py{36,37,38,39}-sphinx{1,2,3,4,latest}
+  # Do not run tests for Python 3.10 and Sphinx3 because it's broken
+  # See https://github.com/sphinx-doc/sphinx/issues/9816
+  py310-sphinx{1,2,4,latest}
 
 [testenv]
 deps =


### PR DESCRIPTION
- use Python 3.10 to run tests
- test with Sphinx 4
- pin docutils to <0.18 on Sphinx 1 and Sphinx 2

Closes #179 