### PR TITLE
Docs: small edits

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,7 +1,9 @@
 Configuration
 =============
 
-The default settings generate the most commonly-used URL pattern: if you have a resource at ``_static/js/logic.js`` and you generate a 404 page with the default settings, the URL for that resource will be ``/en/latest/_static/js/logic.js``.
+The default settings generate the most commonly-used URL pattern on `Read the Docs <https://readthedocs.org>`_:
+if you have a resource at ``_static/js/logic.js`` and you generate a 404 page with the default settings,
+the URL for that resource will be ``/en/latest/_static/js/logic.js``.
 
 For other use cases, you can customize these configuration options in your ``conf.py`` file:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-sphinx-notfound-page - Automatically generate Not Found (404) pages
-===================================================================
+Automatically generate "404 Not Found" pages
+============================================
 
 ``sphinx-notfound-page`` is a Sphinx_ extension to create custom 404 pages and help you to generate proper resource links (js, css, images, etc) to render the page properly.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-Automatically generate "404 Not Found" pages
-============================================
+Generate 404 Not Found Pages Automatically for Sphinx Docs
+==========================================================
 
 ``sphinx-notfound-page`` is a Sphinx_ extension to create custom 404 pages and help you to generate proper resource links (js, css, images, etc) to render the page properly.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,7 +15,7 @@ Install the package
 
       .. prompt:: bash
 
-         pip install git+https://github.com/readthedocs/sphinx-notfound-page@master
+         pip install git+https://github.com/readthedocs/sphinx-notfound-page
 
 
 Once we have the package installed,
@@ -47,10 +47,3 @@ you can build your documentation again and you will see a new file called ``404.
    If you can't see the 404.html file using a local simple web server, it is
    most likely because they often don't support requests for 404 codes. Refer to
    the :doc:`faq` for more information.
-
-.. note::
-
-   This extension requires,
-
-   * Python 2.7+ or 3.x
-   * Sphinx 1.5+ or 2.x


### PR DESCRIPTION
- make the H1 nicer
- remove compatibility since it's useless information at this point
- mention that the common case is because of Read the Docs default URL pattern