### PR TITLE
Don't test for jquery presence with Sphinx 6+

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -548,11 +548,18 @@ def test_sphinx_resource_urls(app, status, warning):
 
     chunks = [
         # Sphinx's resources URLs
-        _get_js_html_link_tag('en', 'latest', 'jquery.js'),
-        _get_js_html_link_tag('en', 'latest', 'underscore.js'),
         _get_js_html_link_tag('en', 'latest', 'doctools.js'),
     ]
 
+    # Sphinx 6+ no longer includes jquery.js and underscore.js
+    if sphinx.version_info < (6, 0, 0):
+        chunks.extend(
+            [
+                _get_js_html_link_tag('en', 'latest', 'jquery.js'),
+                _get_js_html_link_tag('en', 'latest', 'underscore.js'),
+            ]
+        )
+    
     # This file was added to all the HTML pages in Sphinx>=1.8. However, it was
     # only required for search page. Sphinx>=3.4 fixes this and only adds it on
     # search. See (https://github.com/sphinx-doc/sphinx/blob/v3.4.0/CHANGES#L87)


### PR DESCRIPTION
This is a hotfix for an issue we faced when building sphinx-notfound-page with Sphinx 6.1.3 in Fedora.
The jquery files are no longer part of the main Sphinx contents, they were moved to the `sphinxcontrib.jquery` extension.
I couldn't tell whether the presence of the files is truly needed for sphinx-notfound-page to function properly or if they're checked for just to make sure whatever Sphinx injects, was correctly added to the page. I'll appreciate feedback here :)