### PR TITLE
Fix quotes

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -25,7 +25,7 @@ For other use cases, you can customize these configuration options in your ``con
 
       {
           'title': 'Page not found',
-          'body': '<h1>Page not found</h1>\n\nUnfortunately we couldn't find the content you were looking for.',
+          'body': "<h1>Page not found</h1>\n\nUnfortunately we couldn't find the content you were looking for.",
       }
 
    Type: dict


### PR DESCRIPTION
Oops, I messed up the quotes in https://github.com/readthedocs/sphinx-notfound-page/pull/222.

![image](https://github.com/readthedocs/sphinx-notfound-page/assets/1324225/893ac4c4-80ae-42eb-9ca3-bbbba4c75c97)
