### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,6 @@ envlist =
 [testenv]
 deps =
   pytest
-  pdbpp
-  .
   sphinx5: sphinx<6.0
   sphinx6: sphinx<7.0
   sphinx7: sphinx<8.0
@@ -20,7 +18,6 @@ commands = pytest {posargs}
 [testenv:docs]
 deps =
   -r {toxinidir}/docs/requirements.txt
-  .
 changedir = {toxinidir}/docs
 commands =
     sphinx-build -q -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ isolated_build = True
 
 envlist =
   docs
-  py{38,39,310,311}-sphinx{5,6,7,latest}
+  py{38,39,310,311,312}-sphinx{5,6,7,latest}
 
 [testenv]
 deps =


### PR DESCRIPTION
During downstream testing in Fedora Linux I realized there's some misconfiguration in the tox.ini.
I removed pdbpp which is not used anywhere in the tests. 
And added recently released Python 3.12 to the test matrix.