### PR TITLE
Fix spacing in docs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -49,8 +49,8 @@ For other use cases, you can customize these configuration options in your ``con
    Prefix added to all the URLs generated in the 404 page.
 
    Default: ``'/<language>/<version>/'`` where ``<language>`` is ``READTHEDOCS_LANGUAGE`` environment variable
-            and ``<version>`` is ``READTHEDOCS_VERSION`` environment variable.
-            In case these variables are not defined, it defaults to ``/en/latest/``.
+   and ``<version>`` is ``READTHEDOCS_VERSION`` environment variable.
+   In case these variables are not defined, it defaults to ``/en/latest/``.
 
    Type: string
 


### PR DESCRIPTION
Previous:

<img width="719" alt="Screenshot 2023-12-19 at 9 20 32 AM" src="https://github.com/readthedocs/sphinx-notfound-page/assets/25510/b975e263-fc7b-4417-8f93-b7c25e4fa1c1">
