### PR TITLE
fix: Error with sphinx-notfound-page 1.0.3 - 'tuple' object has no at…

### DIFF
--- a/notfound/extension.py
+++ b/notfound/extension.py
@@ -272,7 +272,7 @@ def validate_configs(app, *args, **kwargs):
     notfound_urls_prefix = app.config.notfound_urls_prefix
     default = (
         app.config.values.get("notfound_urls_prefix").default
-        if sphinx.version_info >= (7, 2)
+        if sphinx.version_info >= (7, 3)
         else app.config.values.get("notfound_urls_prefix")[0]
     )
 


### PR DESCRIPTION
Closes #240

## How to test

Building a Sphinx 7.2.X project with this extension in a virtualenv should not return the `'tuple' object has no attribute 'default'` error:

```
# 1. Install Sphinx 7.2.6
pip install sphinx==7.2.6

# 2. Install the extension
git clone https://github.com/readthedocs/sphinx-notfound-page.git
cd sphinx-notfound-page
gh pr checkout 241
pip install .

# 3. Create a new Sphinx project
cd ..
sphinx-quickstart test_project

# 4. Add the extension to conf.py
See https://github.com/readthedocs/sphinx-notfound-page?tab=readme-ov-file#configuration

# 5. Build the Sphinx project
cd test_project
make html
```