### PR TITLE
Test: use tox4 to run the tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,52 +3,37 @@ version: 2.1
 commands:
   run-tox:
     description: "Run tox"
-    parameters:
-      version:
-        type: string
-      sphinx-version:
-        type: string
-        default: "5,6,7,8,latest,dev"
     steps:
       - checkout
-      # NOTE: use Tox 3.x until I understand the syntax for generative environments:
-      # https://tox.wiki/en/stable/user_guide.html#generative-environment-list
-      - run: pip install --user "tox<4"
-      - run: tox -e "<<parameters.version>>-sphinx{<<parameters.sphinx-version>>}"
+      - run: pip install --user tox
+      - run: tox
 
 jobs:
   py38:
     docker:
       - image: 'cimg/python:3.8'
     steps:
-      - run-tox:
-          version: py38
-          sphinx-version: "5,6"
+      - run-tox
   py39:
     docker:
       - image: 'cimg/python:3.9'
     steps:
-      - run-tox:
-          version: py39
-          sphinx-version: "5,6,7"
+      - run-tox
   py310:
     docker:
       - image: 'cimg/python:3.10'
     steps:
-      - run-tox:
-          version: py310
+      - run-tox
   py311:
     docker:
       - image: 'cimg/python:3.11'
     steps:
-      - run-tox:
-          version: py311
+      - run-tox
   py312:
     docker:
       - image: 'cimg/python:3.12'
     steps:
-      - run-tox:
-          version: py312
+      - run-tox
   docs:
     docker:
       - image: 'cimg/python:3.12'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
     steps:
       - checkout
       - run: pip install --user tox
-      - run: tox
+      - run: tox --skip-env docs
 
 jobs:
   py38:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 # https://tox.wiki/en/latest/example/package.html#flit
-isolated_build = True
+isolated_build = true
+skip_missing_interpreters = true
 
 envlist =
   docs


### PR DESCRIPTION
Define https://tox.wiki/en/4.16.0/config.html#skip_missing_interpreters so when running on CircleCI it only runs the environments for the Python versions we have defined.

Closes #243 